### PR TITLE
Remove peer dependency requirement & fix security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -729,9 +729,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "lodash.sortby": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@turf/union": "^6.0.3"
   },
   "peerDependencies": {
-    "mapbox-gl": "^0.50.0"
+    "mapbox-gl": "^1.8.1"
   },
   "devDependencies": {
     "jsdom": "^13.0.0",


### PR DESCRIPTION
The peer requirement just triggers an annoying warning as we upgrade versions of Mapbox, with no value added.

Plus, lodash security vulnerability fun.